### PR TITLE
Use an empty array instead of an empty string when resetting the wcs_subscriptions_with_totals_updated option

### DIFF
--- a/woocommerce-subscriptions-manual-repair.php
+++ b/woocommerce-subscriptions-manual-repair.php
@@ -25,40 +25,42 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * @package		WooCommerce Subscriptions
- * @author		Prospress Inc.
- * @since		1.0
+ * @package     WooCommerce Subscriptions
+ * @author      Prospress Inc.
+ * @since       1.1
  */
 
 function wcs_recalculate_totals() {
-	
-	// If requested, backup and reset the "wcs_subscriptions_with_totals_updated" option
+
+	// If requested, backup and reset the "wcs_subscriptions_with_totals_updated" option.
 	if ( isset( $_GET['reset-updated-subs-option'] ) ) {
 		$old_option = get_option( 'wcs_subscriptions_with_totals_updated', array() );
 		update_option( '_old_wcs_subscriptions_with_totals_updated', $old_option, false );
-		update_option( 'wcs_subscriptions_with_totals_updated', '', false );
+		update_option( 'wcs_subscriptions_with_totals_updated', array(), false );
 		return;
 	}
-	
-	// Use a URL param to act as a flag for when to run the fixes - avoids running fixes in multiple requests at the same time
+
+	// Use a URL param to act as a flag for when to run the fixes - avoids running fixes in multiple requests at the same time.
 	if ( ! isset( $_GET['wcs-recalculate-totals'] ) ) {
 		return;
 	}
 
 	$payment_gateways       = WC()->payment_gateways->payment_gateways();
 	$checked_subscriptions  = get_option( 'wcs_subscriptions_with_totals_updated', array() );
-	$subscriptions_to_check = get_posts( array(
-		'fields'         => 'ids',
-		'orderby'        => 'ID',
-		'order'          => 'DESC',
-		'post_type'      => 'shop_subscription',
-		'posts_per_page' => 50,
-		'post__not_in'   => $checked_subscriptions,
-		'post_status'    => array(
-			'wc-active',
-			'wc-on-hold',
-		),
-	) );
+	$subscriptions_to_check = get_posts(
+		array(
+			'fields'         => 'ids',
+			'orderby'        => 'ID',
+			'order'          => 'DESC',
+			'post_type'      => 'shop_subscription',
+			'posts_per_page' => 50,
+			'post__not_in'   => $checked_subscriptions,
+			'post_status'    => array(
+				'wc-active',
+				'wc-on-hold',
+			),
+		)
+	);
 
 	$logger = new WC_Logger();
 	$logger->add( 'wcs-recalculate-totals', '----------- Initiating Recalculate subscription totals Fixer -----------' );
@@ -73,84 +75,85 @@ function wcs_recalculate_totals() {
 		$order = wc_get_order( $subscription_id );
 		$order_data = $order->get_data();
 		$products_data = array();
-		
+
 		if ( $subscription ) {
-			
+
 			$calc_total = $subscription->calculate_totals();
-			
-			if(isset($_GET['readd'])){
-				// Backup line items (product_id => quantity)
+
+			if ( isset( $_GET['readd'] ) ) {
+				// Backup line items (product_id => quantity).
 				foreach ( $subscription->get_items() as $item_id => $item ) {
 					$qtty = $item['quantity'];
 					$product_id = $item['product_id'];
-					if(isset($item['variation_id']) && $item['variation_id']!=''){
+					if ( isset( $item['variation_id'] ) && '' !== $item['variation_id'] ) {
 						$product_id = $item['variation_id'];
 					}
-					$products_data[$product_id] = $qtty;
+					$products_data[ $product_id ] = $qtty;
 				}
 				$logger->add( 'wcs-recalculate-totals', '* Saved line items ' . var_export( $products_data, true ) );
-				
-				// Delete all order items
-				$subscription->remove_order_items('line_item');
+
+				// Delete all order items.
+				$subscription->remove_order_items( 'line_item' );
 				$logger->add( 'wcs-recalculate-totals', '* Removed order items' );
-				
-				// Add the saved order items
-				foreach($products_data as $product_id => $qty) {
-			        if($qty > 0) {
-			            $product = wc_get_product($product_id);
-			            $subscription->add_product($product, $qty);
-			            $logger->add( 'wcs-recalculate-totals', "* Added $qty units of product #$product_id" );
-			        }
-			    }
-			    	
-			    // Update totals and add an order note
+
+				// Add the saved order items.
+				foreach ( $products_data as $product_id => $qty ) {
+					if ( $qty > 0 ) {
+						$product = wc_get_product( $product_id );
+						$subscription->add_product( $product, $qty );
+						$logger->add( 'wcs-recalculate-totals', "* Added $qty units of product #$product_id" );
+					}
+				}
+
+				// Update totals and add an order note.
 				$subscription->update_taxes();
 				$calc_total = $subscription->calculate_totals();
 				$subscription->save();
-				$order->add_order_note("Order totals recalculated automatically (woocommerce-subscriptions-recalculate-totals)");
-				$logger->add( 'wcs-recalculate-totals', "* Recalculated totals" );
-			
+				$order->add_order_note( 'Order totals recalculated automatically (woocommerce-subscriptions-recalculate-totals)' );
+				$logger->add( 'wcs-recalculate-totals', '* Recalculated totals' );
+
 			}
-		
 		}
 
 		$checked_subscriptions[] = $subscription_id;
 
-		// Update the record on each iteration in case we can't make it through 50 subscriptions in one request
+		// Update the record on each iteration in case we can't make it through 50 subscriptions in one request.
 		update_option( 'wcs_subscriptions_with_totals_updated', $checked_subscriptions, false );
 	}
 }
 add_action( 'init', 'wcs_recalculate_totals' );
 
-function general_admin_notice(){
-	
+function general_admin_notice() {
+
 	if ( ! isset( $_GET['wcs-recalculate-totals'] ) ) {
 		return;
 	}
-	
-    $checked_subscriptions  = get_option( 'wcs_subscriptions_with_totals_updated', array() );
-	$subscriptions_to_check = get_posts( array(
-		'fields'         => 'ids',
-		'orderby'        => 'ID',
-		'order'          => 'DESC',
-		'post_type'      => 'shop_subscription',
-		'posts_per_page' => 50,
-		'post__not_in'   => $checked_subscriptions,
-		'post_status'    => array(
-			'wc-active',
-			'wc-on-hold',
-		),
-	) );
-    
-    if ( $checked_subscriptions!='' && empty($subscriptions_to_check) ) {
-         echo '<div class="notice notice-success is-dismissible">
+
+	$checked_subscriptions  = get_option( 'wcs_subscriptions_with_totals_updated', array() );
+	$subscriptions_to_check = get_posts(
+		array(
+			'fields'         => 'ids',
+			'orderby'        => 'ID',
+			'order'          => 'DESC',
+			'post_type'      => 'shop_subscription',
+			'posts_per_page' => 50,
+			'post__not_in'   => $checked_subscriptions,
+			'post_status'    => array(
+				'wc-active',
+				'wc-on-hold',
+			),
+		)
+	);
+
+	if ( ! empty( $checked_subscriptions ) && empty( $subscriptions_to_check ) ) {
+		echo '<div class="notice notice-success is-dismissible">
              <p><b>All subscriptions have been recalculated! :)</b></p>
              <p>If you want to recalculate all your subscriptions again, you will need to use <mark style="background: #e5e5e5;">"reset-updated-subs-option=true"</mark> parameter</p>
          </div>';
-    }
-    
-    $logger = new WC_Logger();
-    $logger->add( 'wcs-recalculate-totals', '******** All subscriptions have been recalculated! ********' );
-    
+	}
+
+	$logger = new WC_Logger();
+	$logger->add( 'wcs-recalculate-totals', '******** All subscriptions have been recalculated! ********' );
+
 }
-add_action('admin_notices', 'general_admin_notice');
+add_action( 'admin_notices', 'general_admin_notice' );


### PR DESCRIPTION
### Issue Description
When using the reset parameter, the `wcs_subscriptions_with_totals_updated` option is replaced with an empty string instead of the default empty array. This generates an error as it later tries to access this variable as an array. 

### Steps to replicate
1. Activate the plugin and use the `?wcs-recalculate-totals=true` parameter to recalculate the totals of your subscriptions 

2. Use the `?reset-updated-subs-option=true` parameter to reset the `wcs_subscriptions_with_totals_updated` option (its content will be replaced with an empty string)

3. Use the `?wcs-recalculate-totals=true` parameter to recalculate the totals again.

### Expected result
The plugin should be able to update the totals again without any errors

### Result
The following error appears when trying to update the totals after the reset:

> PHP Fatal error:  Uncaught Error: [] operator not supported for strings in /Applications/MAMP/htdocs/subscriptions/wp-content/plugins/woocommerce-subscriptions-recalculate-totals/woocommerce-subscriptions-manual-repair.php:117

### Fix
I'm updating the code to replace the `wcs_subscriptions_with_totals_updated` option with an empty array instead of an empty string. There's no need to use an empty string and using an empty array will make sure that we never get this problem again. 

Fixes #1 and #2 