### PR TITLE
Update tax strings

### DIFF
--- a/woocommerce-subscriptions-manual-repair.php
+++ b/woocommerce-subscriptions-manual-repair.php
@@ -92,6 +92,7 @@ function wcs_recalculate_totals() {
 				
 				// Delete all order items
 				$subscription->remove_order_items('line_item');
+				$subscription->remove_order_items('tax');
 				$logger->add( 'wcs-recalculate-totals', '* Removed order items' );
 				
 				// Add the saved order items


### PR DESCRIPTION
Without removing `tax` order items the new tax was correctly calculated, but the tax name remained the same. This fixes it. 

Background: In Germany we have a tax change (https://www.bundesregierung.de/breg-en/search/corona-steuerhilfegesetz-1760128): "Stronger private consumption can help revitalise the domestic economy. To encourage more people to buy now rather than wait, value added tax rates have been cut from 19 to 16 per cent and from 7 to 5 per cent for a limited period. The reduced rates will apply from 1 July to 31 December 2020."

For instance, the reduced tax named "VAT 7%"  with 7% was reduced to 5%. Without this fix the tax would be correctly re-calculated but the VAT string would still say "VAT 7%" though it was already changed to "VAT 5%" in the settings.